### PR TITLE
Update ex02.c

### DIFF
--- a/C07/ex02.c
+++ b/C07/ex02.c
@@ -16,12 +16,12 @@ void do_test(int min, int max)
 
 int main(void)
 {
-	int *p;
+	int *p = NULL;
 	printf("ft_ultimate_range(&p, 0, 0): %d, %p\n", ft_ultimate_range(&p, 0, 0), p);
 	printf("ft_ultimate_range(&p, 1, 0): %d, %p\n", ft_ultimate_range(&p, 1, 0), p);
 	printf("ft_ultimate_range(&p, 2, 0): %d, %p\n", ft_ultimate_range(&p, 1, 0), p);
-	printf("ft_ultimate_range(&p, 0, 3): %d, %d\n", ft_ultimate_range(&p, 0, 3), p > 0);
-	printf("ft_ultimate_range(&p, 2, 5122): %d, %d\n", ft_ultimate_range(&p, 2, 5122), p > 0);
+	printf("ft_ultimate_range(&p, 0, 3): %d, %d\n", ft_ultimate_range(&p, 0, 3), p > (int *)0);
+	printf("ft_ultimate_range(&p, 2, 5122): %d, %d\n", ft_ultimate_range(&p, 2, 5122), p > (int *)0);
 	// printf("ft_range(0, 2147483647): %p\n", ft_range(0, 2147483647));
 	do_test(-5, 5);
 	do_test(-10, 10);


### PR DESCRIPTION
I had the same problem as with ft_range and p was uninitialized

ex02.c: In function ‘main’:
ex02.c:23:81: error: ordered comparison of pointer with integer zero [-Werror=extra]
 printf("ft_ultimate_range(&p, 0, 3): %d, %d\n", ft_ultimate_range(&p, 0, 3), p > 0);
                                                                                ^

ex02.c:24:87: error: ordered comparison of pointer with integer zero [-Werror=extra]
 ("ft_ultimate_range(&p, 2, 5122): %d, %d\n", ft_ultimate_range(&p, 2, 5122), p > 0);
                                                                                ^

ex02.c:20:2: error: ‘p’ is used uninitialized in this function [-Werror=uninitialized]
  printf("ft_ultimate_range(&p, 0, 0): %d, %p\n", ft_ultimate_range(&p, 0, 0), p);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors